### PR TITLE
Handle crumbs changing

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -27,17 +27,20 @@ class BreadcrumbsProvider extends Component<Props, State> {
     }))
   }
 
+  findCrumb = (crumb: Crumb, crumbs: Crumb[]): number | undefined => {
+    for (let i = 0; i < crumbs.length; i++) {
+      const { title, path } = crumbs[i];
+      if (crumb.title === title && crumb.path === path) {
+        return i;
+      }
+    }
+
+    return undefined;
+  }
+
   removeCrumb = (crumbToRemove: Crumb) => {
     this.setState(({ crumbs: prevCrumbs }) => {
-      let crumbIndex: number | undefined
-
-      for (let i = 0; i < prevCrumbs.length; i++) {
-        const { title, path } = prevCrumbs[i]
-        if (crumbToRemove.title === title && crumbToRemove.path === path) {
-          crumbIndex = i
-          break
-        }
-      }
+      const crumbIndex = this.findCrumb(crumbToRemove, prevCrumbs);
 
       let crumbs
 
@@ -52,6 +55,23 @@ class BreadcrumbsProvider extends Component<Props, State> {
     })
   }
 
+  replaceCrumb = (crumbToReplace: Crumb, crumbReplacement: Crumb) => {
+    this.setState(({ crumbs: prevCrumbs }) => {
+      const crumbIndex = this.findCrumb(crumbToReplace, prevCrumbs);
+
+      let crumbs
+
+      if (crumbIndex !== undefined) {
+        crumbs = [...prevCrumbs];
+        crumbs.splice(crumbIndex, 1, crumbReplacement);
+      } else {
+        crumbs = prevCrumbs;
+      }
+
+      return { crumbs };
+    })
+  }
+
   render() {
     const { crumbs } = this.state
     const { children } = this.props
@@ -59,7 +79,8 @@ class BreadcrumbsProvider extends Component<Props, State> {
     const context = {
       crumbs,
       addCrumb: this.addCrumb,
-      removeCrumb: this.removeCrumb
+      removeCrumb: this.removeCrumb,
+      replaceCrumb: this.replaceCrumb
     }
 
     return <Provider value={context}>{children}</Provider>

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,6 +6,7 @@ interface BreadcrumbContext {
   crumbs: Crumb[]
   addCrumb: (crumb: Crumb) => void
   removeCrumb: (crumb: Crumb) => void
+  replaceCrumb: (oldCrumb: Crumb, newCrumb: Crumb) => void
 }
 
 /* istanbul ignore next */
@@ -14,7 +15,9 @@ const defaultContext: BreadcrumbContext = {
   // tslint:disable-next-line
   addCrumb: (crumb: Crumb) => {},
   // tslint:disable-next-line
-  removeCrumb: (crumb: Crumb) => {}
+  removeCrumb: (crumb: Crumb) => {},
+  // tslint:disable-next-line
+  replaceCrumb: (oldCrumb: Crumb, newCrumb: Crumb) => {}
 }
 
 const { Provider, Consumer } = React.createContext(defaultContext)

--- a/src/withBreadcrumb.tsx
+++ b/src/withBreadcrumb.tsx
@@ -7,6 +7,7 @@ interface Props {
   crumb: Crumb
   addCrumb: (crumb: Crumb) => void
   removeCrumb: (crumb: Crumb) => void
+  replaceCrumb: (oldCrumb: Crumb, newCrumb: Crumb) => void
 }
 
 /**
@@ -26,6 +27,16 @@ class WithBreadcrumbWrapper extends Component<Props> {
     removeCrumb(crumb)
   }
 
+  componentDidUpdate(prevProps: Props) {
+    const { crumb, replaceCrumb } = this.props
+    if (
+      prevProps.crumb.title !== crumb.title ||
+      prevProps.crumb.path !== crumb.path
+    ) {
+      replaceCrumb(prevProps.crumb, crumb)
+    }
+  }
+
   render() {
     return this.props.children
   }
@@ -35,11 +46,12 @@ export const withBreadcrumb = <PropsType extends {} = any>(
   crumb: Crumb | ((props: PropsType) => Crumb)
 ) => (WrappedComponent: ComponentType<PropsType>) => (props: PropsType) => (
   <BreadcrumbsConsumer>
-    {({ addCrumb, removeCrumb }) => (
+    {({ addCrumb, removeCrumb, replaceCrumb }) => (
       <WithBreadcrumbWrapper
         crumb={typeof crumb === 'function' ? crumb(props) : crumb}
         addCrumb={addCrumb}
         removeCrumb={removeCrumb}
+        replaceCrumb={replaceCrumb}
       >
         <WrappedComponent {...props} />
       </WithBreadcrumbWrapper>


### PR DESCRIPTION
If crumbs are, e.g., derived from props or state, and that state changes, this ensures that the breadcrumb gets updated, too.

(I don't have a good repro for this easy to hand, but it's pretty easy to see if you pass a function into `withBreadcrumb`)