### PR TITLE
Update to React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepack": "yarn compile"
   },
   "peerDependencies": {
-    "react": "16"
+    "react": "16 || 17"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.13",
@@ -49,8 +49,8 @@
     "jest": "^24.1.0",
     "lint-staged": "^9.0.0",
     "prettier": "^1.14.2",
-    "react": "^16.4.2",
-    "react-dom": "^16.4.2",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "ts-jest": "^25.1.0",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.14.0",


### PR DESCRIPTION
Resolves `has incorrect peer dependency` in projects using this with React 17.